### PR TITLE
Fixed minor styling on the logos for both mobile and non-mobile

### DIFF
--- a/client/public/usenano.css
+++ b/client/public/usenano.css
@@ -97,3 +97,24 @@ tr img {
 .moreInfo {
    background-color: #ffffff;
 }
+
+.logo-link {
+  padding: 1rem;
+  display: block;
+}
+
+.logo-link > .logo {
+  width: 5rem;
+}
+
+@media only screen and (min-width: 768px){
+  .logo-link {
+    display: inline;
+  }
+  .logo-link > .logo {
+    width: 8%;
+  }
+  .company-name {
+    display: inline;
+  }
+}

--- a/client/src/components/List.js
+++ b/client/src/components/List.js
@@ -98,10 +98,10 @@ class List extends Component {
           <tr style={{cursor: 'pointer'}} key={i}
             onClick={() => this.setState(this.state.selected === data.name ? {selected: ""} : {selected: data.name})}>
             <td>
-              <a target="_blank" rel="noopener noreferrer" href={data.websitelink} alt={data.name}>
-                <img alt={data.name} src={'logos/' + data.logo} />
+              <a className="logo-link" target="_blank" rel="noopener noreferrer" href={data.websitelink} alt={data.name}>
+                <img alt={data.name} className="logo" src={'logos/' + data.logo} />
               </a>
-              <span> <a target="_blank" rel="noopener noreferrer" href={data.websitelink}>{data.name}</a></span>
+              <span className="company-name"> <a className="name" target="_blank" rel="noopener noreferrer" href={data.websitelink}>{data.name}</a></span>
             </td>
             <td>{data.category}</td>
             <td>{data.discount}</td>


### PR DESCRIPTION
This should fix the spacing for the logos. 

Mobile view:

![image](https://user-images.githubusercontent.com/46548/43047184-3339dcd8-8e06-11e8-944c-65442194bce5.png)


Desktop view:

![image](https://user-images.githubusercontent.com/46548/43047192-3ab9cc02-8e06-11e8-8be5-80340568eb23.png)
